### PR TITLE
feat: add anchor feature for markdown renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "halo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "halo",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "https://github.com/halo-sigs/vscode-extension-halo/blob/main/LICENSE",
       "dependencies": {
         "@halo-dev/api-client": "^2.8.0-rc.1",
@@ -15,6 +15,7 @@
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0",
         "markdown-it": "^13.0.1",
+        "markdown-it-anchor": "^8.6.7",
         "preferences": "^2.0.2",
         "transliteration": "^2.3.5"
       },
@@ -305,14 +306,12 @@
     "node_modules/@types/linkify-it": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
-      "dev": true
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
     },
     "node_modules/@types/markdown-it": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
       "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-      "dev": true,
       "dependencies": {
         "@types/linkify-it": "*",
         "@types/mdurl": "*"
@@ -321,8 +320,7 @@
     "node_modules/@types/mdurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "dev": true
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -2327,6 +2325,15 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
     "node_modules/mdurl": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.0",
     "markdown-it": "^13.0.1",
+    "markdown-it-anchor": "^8.6.7",
     "preferences": "^2.0.2",
     "transliteration": "^2.3.5"
   },

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -11,13 +11,13 @@ import {
 import axios, { AxiosInstance } from "axios";
 import * as vscode from "vscode";
 import { mergeMatter, readMatter } from "../utils/yaml";
-import MarkdownIt = require("markdown-it");
 import path = require("path");
 import { randomUUID } from "crypto";
 import { slugify } from "transliteration";
 import * as FormData from "form-data";
 import * as fs from "fs";
 import { Site } from "../utils/site-store";
+import markdownIt from "../utils/markdown";
 
 class HaloService {
   private readonly site: Site;
@@ -116,13 +116,7 @@ class HaloService {
     }
 
     params.content.raw = raw;
-    params.content.content = new MarkdownIt({
-      html: true,
-      xhtmlOut: true,
-      breaks: true,
-      linkify: true,
-      typographer: true,
-    }).render(raw);
+    params.content.content = markdownIt.render(raw);
 
     // restore metadata
     if (matterData.title) {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,14 @@
+import MarkdownIt = require("markdown-it");
+import MarkdownItAnchor from "markdown-it-anchor";
+
+const markdownIt = new MarkdownIt({
+  html: true,
+  xhtmlOut: true,
+  breaks: true,
+  linkify: true,
+  typographer: true,
+});
+
+markdownIt.use(MarkdownItAnchor);
+
+export default markdownIt;


### PR DESCRIPTION
为渲染之后的 HTML 添加 heading 的锚定位（id）。

<img width="636" alt="图片" src="https://github.com/halo-sigs/vscode-extension-halo/assets/21301288/5c6868c1-55aa-47ce-bf01-ee8b616c54f9">

/kind feature

Fixes #7 

```release-note
None
```